### PR TITLE
[TM-54] Decline Funding For An Approved Application

### DIFF
--- a/src/SFA.DAS.LevyTransferMatching.Functions.TestHarness/SFA.DAS.LevyTransferMatching.Functions.TestHarness.csproj
+++ b/src/SFA.DAS.LevyTransferMatching.Functions.TestHarness/SFA.DAS.LevyTransferMatching.Functions.TestHarness.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="SFA.DAS.CommitmentsV2.Messages" Version="3.88.5" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
     <PackageReference Include="SFA.DAS.EmployerAccounts.Messages" Version="1.6.2978" />
-    <PackageReference Include="SFA.DAS.LevyTransferMatching.Messages" Version="0.1.35-prerelease-19" />
+    <PackageReference Include="SFA.DAS.LevyTransferMatching.Messages" Version="0.1.52-prerelease-5" />
   </ItemGroup>
 
 </Project>

--- a/src/SFA.DAS.LevyTransferMatching.Functions.TestHarness/TestHarness.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Functions.TestHarness/TestHarness.cs
@@ -30,6 +30,7 @@ namespace SFA.DAS.LevyTransferMatching.Functions.TestHarness
                 Console.WriteLine("B - ChangedAccountNameEvent");
                 Console.WriteLine("C - ApplicationApprovedEvent");
                 Console.WriteLine("D - TransferRequestApprovedEvent");
+                Console.WriteLine("E - ApplicationFundingDeclinedEvent");
                 Console.WriteLine("X - Exit");
                 Console.WriteLine("Press [Key] for Test Option");
                 key = Console.ReadKey().Key;
@@ -57,6 +58,11 @@ namespace SFA.DAS.LevyTransferMatching.Functions.TestHarness
                             await _publisher.Publish(new TransferRequestApprovedEvent(1, 1, DateTime.UtcNow, new CommitmentsV2.Types.UserInfo(), 1, 300, 2017));
                             Console.WriteLine();
                             Console.WriteLine($"Published TransferRequestApprovedEvent");
+                            break;
+                        case ConsoleKey.E:
+                            await _publisher.Publish(new ApplicationFundingDeclinedEvent(1, 1, DateTime.UtcNow, 10000));
+                            Console.WriteLine();
+                            Console.WriteLine("Published ApplicationFundingDeclinedEvent");
                             break;
                     }
                 }

--- a/src/SFA.DAS.LevyTransferMatching.Functions.UnitTests/EventHandlers/ApplicationFundingDeclinedEventHandlerTests.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Functions.UnitTests/EventHandlers/ApplicationFundingDeclinedEventHandlerTests.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading.Tasks;
+using AutoFixture;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.LevyTransferMatching.Functions.Api;
+using SFA.DAS.LevyTransferMatching.Functions.Events;
+using SFA.DAS.LevyTransferMatching.Messages.Events;
+
+namespace SFA.DAS.LevyTransferMatching.Functions.UnitTests.EventHandlers
+{
+    [TestFixture]
+    public class ApplicationFundingDeclinedEventHandlerTests
+    {
+        private ApplicationFundingDeclinedEventHandler _handler;
+        private ApplicationFundingDeclinedEvent _event;
+        private Mock<ILevyTransferMatchingApi> _api;
+        private readonly Fixture _fixture = new Fixture();
+
+        [SetUp]
+        public void Setup()
+        {
+            _api = new Mock<ILevyTransferMatchingApi>();
+
+            _event = _fixture.Create<ApplicationFundingDeclinedEvent>();
+
+            _handler = new ApplicationFundingDeclinedEventHandler(_api.Object);
+        }
+
+        [Test]
+        public async Task Run_Invokes_ApplicationFundingDeclined_Api_Endpoint()
+        {
+            await _handler.Run(_event, Mock.Of<ILogger>());
+
+            _api.Verify(x => x.ApplicationFundingDeclined(It.Is<ApplicationFundingDeclinedRequest>(r =>
+                r.ApplicationId == _event.ApplicationId &&
+                r.PledgeId == _event.PledgeId &&
+                r.Amount == _event.Amount)));
+        }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching.Functions/Api/ApplicationFundingDeclinedRequest.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Functions/Api/ApplicationFundingDeclinedRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.LevyTransferMatching.Functions.Api
+{
+    public class ApplicationFundingDeclinedRequest
+    {
+        public int ApplicationId { get; set; }
+        public int PledgeId { get; set; }
+        public int Amount { get; set; }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching.Functions/Api/ILevyTransferMatchingApi.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Functions/Api/ILevyTransferMatchingApi.cs
@@ -13,5 +13,8 @@ namespace SFA.DAS.LevyTransferMatching.Functions.Api
 
         [Post("functions/debit-application")]
         Task DebitApplication([Body] TransferRequestApprovedRequest request);
+
+        [Post("functions/application-funding-declined")]
+        Task ApplicationFundingDeclined([Body] ApplicationFundingDeclinedRequest request);
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Functions/Events/ApplicationFundingDeclinedEventHandler.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Functions/Events/ApplicationFundingDeclinedEventHandler.cs
@@ -1,0 +1,46 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using RestEase;
+using SFA.DAS.LevyTransferMatching.Functions.Api;
+using SFA.DAS.LevyTransferMatching.Infrastructure;
+using SFA.DAS.LevyTransferMatching.Messages.Events;
+using SFA.DAS.NServiceBus.AzureFunction.Attributes;
+
+namespace SFA.DAS.LevyTransferMatching.Functions.Events
+{
+    public class ApplicationFundingDeclinedEventHandler
+    {
+        private readonly ILevyTransferMatchingApi _api;
+
+        public ApplicationFundingDeclinedEventHandler(ILevyTransferMatchingApi api)
+        {
+            _api = api;
+        }
+
+        [FunctionName("RunApplicationFundingDeclinedEvent")]
+        public async Task Run([NServiceBusTrigger(Endpoint = QueueNames.ApplicationFundingDeclined)] ApplicationFundingDeclinedEvent @event, ILogger log)
+        {
+            log.LogInformation($"Handling {nameof(ApplicationFundingDeclinedEvent)} handler for application {@event.ApplicationId}");
+         
+            var request = new ApplicationFundingDeclinedRequest
+            {
+                PledgeId = @event.PledgeId,
+                ApplicationId = @event.ApplicationId,
+                Amount = @event.Amount,
+            };
+         
+            try
+            {
+                await _api.ApplicationFundingDeclined(request);
+            }
+            catch (ApiException ex)
+            {
+                if (ex.StatusCode != HttpStatusCode.BadRequest) throw;
+         
+                log.LogError(ex, $"Error handling ApplicationApprovedEvent for application {@event.ApplicationId}");
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching.Functions/SFA.DAS.LevyTransferMatching.Functions.csproj
+++ b/src/SFA.DAS.LevyTransferMatching.Functions/SFA.DAS.LevyTransferMatching.Functions.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
     <PackageReference Include="SFA.DAS.EmployerAccounts.Messages" Version="1.6.2978" />
     <PackageReference Include="SFA.DAS.Http" Version="3.2.62" />
-    <PackageReference Include="SFA.DAS.LevyTransferMatching.Messages" Version="0.1.35-prerelease-19" />
+    <PackageReference Include="SFA.DAS.LevyTransferMatching.Messages" Version="0.1.52-prerelease-5" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.2.1" />
     <PackageReference Include="SFA.DAS.NServiceBus.AzureFunction" Version="16.0.21" />
   </ItemGroup>

--- a/src/SFA.DAS.LevyTransferMatching.Infrastructure/QueueNames.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Infrastructure/QueueNames.cs
@@ -8,6 +8,6 @@
         public const string ApplicationApprovedEvent = "SFA.DAS.LevyTransferMatching.ApplicationApproved";
         public const string PledgeDebitFailed = "SFA.DAS.LevyTransferMatching.PledgeDebitFailed";
         public const string TransferRequestApprovedEvent = "SFA.DAS.LTM.TransferRequestApproved";
-        public const string ApplicationFundingDeclined = "SFA.DAS.LevyTransferMatching.ApplicationFundingDeclined";
+        public const string ApplicationFundingDeclined = "SFA.DAS.LTM.ApplicationFundingDeclined";
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Infrastructure/QueueNames.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Infrastructure/QueueNames.cs
@@ -8,5 +8,6 @@
         public const string ApplicationApprovedEvent = "SFA.DAS.LevyTransferMatching.ApplicationApproved";
         public const string PledgeDebitFailed = "SFA.DAS.LevyTransferMatching.PledgeDebitFailed";
         public const string TransferRequestApprovedEvent = "SFA.DAS.LTM.TransferRequestApproved";
+        public const string ApplicationFundingDeclined = "SFA.DAS.LevyTransferMatching.ApplicationFundingDeclined";
     }
 }


### PR DESCRIPTION
Creates an event handler for the new `ApplicationFundingDeclined` event.

See also:

* https://github.com/SkillsFundingAgency/das-employer-config/pull/1049
* https://github.com/SkillsFundingAgency/das-data-management/pull/252
* https://github.com/SkillsFundingAgency/das-levy-transfer-matching-web/pull/111
* https://github.com/SkillsFundingAgency/das-apim-endpoints/pull/533
* https://github.com/SkillsFundingAgency/das-levy-transfer-matching-api/pull/59